### PR TITLE
Change no default export rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -70,7 +70,7 @@
     "number-literal-format": true,
     "no-parameter-properties": true,
     "indent": [true, "spaces", 2],
-    "no-default-export": false,
+    "no-default-export": true,
     "no-duplicate-imports": true,
     "no-duplicate-switch-case": true,
     "prefer-readonly": true,


### PR DESCRIPTION
https://basarat.gitbooks.io/typescript/content/docs/tips/defaultIsBad.html

Any project we have that currently uses default exports should at least have `"match-default-export-name": true` set

The only benefit I can see to default exports is that you promote having one export per file, but usually that's not practical anyway